### PR TITLE
Simplify boundedrand

### DIFF
--- a/pcg_basic.c
+++ b/pcg_basic.c
@@ -78,34 +78,8 @@ uint32_t pcg32_random()
 
 uint32_t pcg32_boundedrand_r(pcg32_random_t* rng, uint32_t bound)
 {
-    // To avoid bias, we need to make the range of the RNG a multiple of
-    // bound, which we do by dropping output less than a threshold.
-    // A naive scheme to calculate the threshold would be to do
-    //
-    //     uint32_t threshold = 0x100000000ull % bound;
-    //
-    // but 64-bit div/mod is slower than 32-bit div/mod (especially on
-    // 32-bit platforms).  In essence, we do
-    //
-    //     uint32_t threshold = (0x100000000ull-bound) % bound;
-    //
-    // because this version will calculate the same modulus, but the LHS
-    // value is less than 2^32.
-
-    uint32_t threshold = -bound % bound;
-
-    // Uniformity guarantees that this loop will terminate.  In practice, it
-    // should usually terminate quickly; on average (assuming all bounds are
-    // equally likely), 82.25% of the time, we can expect it to require just
-    // one iteration.  In the worst case, someone passes a bound of 2^31 + 1
-    // (i.e., 2147483649), which invalidates almost 50% of the range.  In 
-    // practice, bounds are typically small and only a tiny amount of the range
-    // is eliminated.
-    for (;;) {
-        uint32_t r = pcg32_random_r(rng);
-        if (r >= threshold)
-            return r % bound;
-    }
+    uint64_t r = pcg32_random_r(rng);
+    return r * bound >> 32u;
 }
 
 


### PR DESCRIPTION
Replace the loop with [0, 1) multiplied by `bound`. Since `pcg32_random_r` returns a maximum value of 2^32 - 1, you can use a right shift by 32 bits instead of division.