### PR TITLE
Update pcg_basic.c function definition to match header

### DIFF
--- a/pcg_basic.c
+++ b/pcg_basic.c
@@ -66,7 +66,7 @@ uint32_t pcg32_random_r(pcg32_random_t* rng)
     return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
 }
 
-uint32_t pcg32_random()
+uint32_t pcg32_random(void)
 {
     return pcg32_random_r(&pcg32_global);
 }


### PR DESCRIPTION
If compiled with -Wstrict-prototypes using emcc (the emscripten compiler), it successfully catches that this function header is empty (though it is correctly 'void' in the associated header)

```
error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
   67 | uint32_t pcg32_random() { return pcg32_random_r(&pcg32_global); }
      |                      ^
      |                       void
```